### PR TITLE
[otto.yoon] 방탈출 인증관리 step1 & 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+# 1단계 - 로그인
+
 ## 기능 요구사항
 
 - [x] 토큰 발급하는 API 생성
-- [ ] 내 정보 조회하기
-    - [ ] 토큰을 이용하여 본인 정보 응답하기
+- [x] 내 정보 조회하기
+    - [x] 토큰을 이용하여 본인 정보 응답하기
 
 ## 프로그래밍 요구사항
 
@@ -52,4 +54,49 @@ Content-Type: application/json
     "name": "name",
     "phone": "010-1234-5678"
 }
+```
+
+# 2단계 - 로그인 리팩터링
+
+## 기능 요구사항
+
+- [x] 예약하기, 예약취소 개선
+    - [x] 아래의 API 설계에 맞춰 API 스펙을 변경한다.
+    - [x] 비로그인 사용자는 예약이 불가능하다.
+    - [x] 자신의 예약이 아닌 경우 예약 취소가 불가능하다.
+
+## 프로그래밍 요구사항
+
+- [x] HandlerMethodArgumentResolver를 활용한다.
+
+## API 설계
+
+### 예약 생성
+
+```
+POST /reservations HTTP/1.1
+authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjYzMjk4NTkwLCJleHAiOjE2NjMzMDIxOTAsInJvbGUiOiJBRE1JTiJ9.-OO1QxEpcKhmC34HpmuBhlnwhKdZ39U8q91QkTdH9i0
+content-type: application/json; charset=UTF-8
+host: localhost:8080
+
+{
+    // 필요한 값
+    // ex) "scheduleId": 1
+}
+```
+
+```
+HTTP/1.1 201 Created
+Location: /reservations/1
+```
+
+### 예약 삭제
+
+```
+DELETE /reservations/1 HTTP/1.1
+authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjYzMjk5MDcwLCJleHAiOjE2NjMzMDI2NzAsInJvbGUiOiJBRE1JTiJ9.zgz7h7lrKLNw4wP9I0W8apQnMUn3WHnmqQ1N2jNqwlQ
+```
+
+```
+HTTP/1.1 204
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+## 기능 요구사항
+
+- [x] 토큰 발급하는 API 생성
+- [ ] 내 정보 조회하기
+    - [ ] 토큰을 이용하여 본인 정보 응답하기
+
+## 프로그래밍 요구사항
+
+- 인증 로직은 Controller에서 구현하기 보다는 재사용이 용이하도록 분리하여 구현하다.
+    - 가능하면 Controller와 인증 로직을 분리한다.
+- 토큰을 이용한 인증 프로세스에 대해 이해가 어려운 경우 페어와 함께 추가학습을 진행한다.
+
+## API 설계
+
+### 토큰 발급
+
+```
+POST /login/token HTTP/1.1
+accept: */*
+content-type: application/json; charset=UTF-8
+
+{
+    "username": "username",
+    "password": "password"
+}
+```
+
+```
+HTTP/1.1 200 
+Content-Type: application/json
+
+{
+    "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjYzMjk4NTEwLCJleHAiOjE2NjMzMDIxMTAsInJvbGUiOiJBRE1JTiJ9.7pxE1cjS51snIrfk21m2Nw0v08HCjgkRD2WSxTK318M"
+}
+```
+
+### 내 정보 조회
+
+```
+GET /members/me HTTP/1.1
+authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjYzMjk4NTkwLCJleHAiOjE2NjMzMDIxOTAsInJvbGUiOiJBRE1JTiJ9.-OO1QxEpcKhmC34HpmuBhlnwhKdZ39U8q91QkTdH9i0
+```
+
+```
+HTTP/1.1 200 
+Content-Type: application/json
+
+{
+    "id": 1,
+    "username": "username",
+    "password": "password",
+    "name": "name",
+    "phone": "010-1234-5678"
+}
+```

--- a/src/main/java/nextstep/auth/AuthController.java
+++ b/src/main/java/nextstep/auth/AuthController.java
@@ -1,0 +1,21 @@
+package nextstep.auth;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @PostMapping("/login/token")
+    public ResponseEntity login(@RequestBody TokenRequest tokenRequest) {
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
+        String token = jwtTokenProvider.createToken(tokenRequest.getUsername());
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new TokenResponse(token));
+    }
+
+}

--- a/src/main/java/nextstep/member/AuthenticationPrincipal.java
+++ b/src/main/java/nextstep/member/AuthenticationPrincipal.java
@@ -1,0 +1,12 @@
+package nextstep.member;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+    boolean required() default true;
+}

--- a/src/main/java/nextstep/member/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/member/AuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,37 @@
+package nextstep.member;
+
+import nextstep.auth.JwtTokenProvider;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final LoginService loginService;
+
+    public AuthenticationPrincipalArgumentResolver(LoginService loginService) {
+        this.loginService = loginService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
+        HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = httpServletRequest.getHeader("authorization").substring("Bearer ".length());
+        String username = jwtTokenProvider.getPrincipal(token);
+        Member member = loginService.findByUsername(username);
+        return LoginMember.of(member);
+    }
+
+}

--- a/src/main/java/nextstep/member/LoginMember.java
+++ b/src/main/java/nextstep/member/LoginMember.java
@@ -1,0 +1,36 @@
+package nextstep.member;
+
+public class LoginMember {
+
+    private Long id;
+    private String username;
+    private String name;
+    private String phone;
+
+    public LoginMember(Long id, String username, String name, String phone) {
+        this.id = id;
+        this.username = username;
+        this.name = name;
+        this.phone = phone;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public static LoginMember of(Member member) {
+        return new LoginMember(member.getId(), member.getUsername(), member.getName(), member.getPhone());
+    }
+}

--- a/src/main/java/nextstep/member/LoginService.java
+++ b/src/main/java/nextstep/member/LoginService.java
@@ -3,10 +3,10 @@ package nextstep.member;
 import org.springframework.stereotype.Service;
 
 @Service
-public class MemberService {
+public class LoginService {
     private MemberDao memberDao;
 
-    public MemberService(MemberDao memberDao) {
+    public LoginService(MemberDao memberDao) {
         this.memberDao = memberDao;
     }
 
@@ -14,8 +14,7 @@ public class MemberService {
         return memberDao.save(memberRequest.toEntity());
     }
 
-    public Member findById(Long id) {
-        return memberDao.findById(id);
+    public Member findByUsername(String username) {
+        return memberDao.findByUsername(username);
     }
-
 }

--- a/src/main/java/nextstep/member/Member.java
+++ b/src/main/java/nextstep/member/Member.java
@@ -45,4 +45,5 @@ public class Member {
     public boolean checkWrongPassword(String password) {
         return !this.password.equals(password);
     }
+    
 }

--- a/src/main/java/nextstep/member/MemberController.java
+++ b/src/main/java/nextstep/member/MemberController.java
@@ -1,8 +1,10 @@
 package nextstep.member;
 
+import nextstep.auth.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 
 @RestController
@@ -21,9 +23,11 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity me() {
-        Long id = 1L;
-        Member member = memberService.findById(id);
+    public ResponseEntity me(HttpServletRequest httpServletRequest) {
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
+        String token = httpServletRequest.getHeader("authorization").substring("Bearer ".length());
+        String username = jwtTokenProvider.getPrincipal(token);
+        Member member = memberService.findByUsername(username);
         return ResponseEntity.ok(member);
     }
 }

--- a/src/main/java/nextstep/member/MemberController.java
+++ b/src/main/java/nextstep/member/MemberController.java
@@ -1,10 +1,8 @@
 package nextstep.member;
 
-import nextstep.auth.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 
 @RestController
@@ -17,17 +15,17 @@ public class MemberController {
     }
 
     @PostMapping
-    public ResponseEntity createMember(@RequestBody MemberRequest memberRequest) {
+    public ResponseEntity<Void> createMember(@RequestBody MemberRequest memberRequest) {
         Long id = memberService.create(memberRequest);
         return ResponseEntity.created(URI.create("/members/" + id)).build();
     }
 
     @GetMapping("/me")
-    public ResponseEntity me(HttpServletRequest httpServletRequest) {
-        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
-        String token = httpServletRequest.getHeader("authorization").substring("Bearer ".length());
-        String username = jwtTokenProvider.getPrincipal(token);
-        Member member = memberService.findByUsername(username);
-        return ResponseEntity.ok(member);
+    public ResponseEntity<LoginMember> me(@AuthenticationPrincipal LoginMember loginMember) {
+//        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
+//        String token = httpServletRequest.getHeader("authorization").substring("Bearer ".length());
+//        String username = jwtTokenProvider.getPrincipal(token);
+//        Member member = memberService.findByUsername();
+        return ResponseEntity.ok(loginMember);
     }
 }

--- a/src/main/java/nextstep/member/MemberController.java
+++ b/src/main/java/nextstep/member/MemberController.java
@@ -22,10 +22,6 @@ public class MemberController {
 
     @GetMapping("/me")
     public ResponseEntity<LoginMember> me(@AuthenticationPrincipal LoginMember loginMember) {
-//        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
-//        String token = httpServletRequest.getHeader("authorization").substring("Bearer ".length());
-//        String username = jwtTokenProvider.getPrincipal(token);
-//        Member member = memberService.findByUsername();
         return ResponseEntity.ok(loginMember);
     }
 }

--- a/src/main/java/nextstep/member/MemberService.java
+++ b/src/main/java/nextstep/member/MemberService.java
@@ -17,4 +17,8 @@ public class MemberService {
     public Member findById(Long id) {
         return memberDao.findById(id);
     }
+
+    public Member findByUsername(String username) {
+        return memberDao.findByUsername(username);
+    }
 }

--- a/src/main/java/nextstep/member/config/WebMvcConfiguration.java
+++ b/src/main/java/nextstep/member/config/WebMvcConfiguration.java
@@ -1,0 +1,22 @@
+package nextstep.member.config;
+
+import nextstep.member.AuthenticationPrincipalArgumentResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+    @Autowired
+    private AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationPrincipalArgumentResolver);
+    }
+
+}

--- a/src/main/java/nextstep/reservation/ReservationController.java
+++ b/src/main/java/nextstep/reservation/ReservationController.java
@@ -1,5 +1,7 @@
 package nextstep.reservation;
 
+import nextstep.member.AuthenticationPrincipal;
+import nextstep.member.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,8 +19,8 @@ public class ReservationController {
     }
 
     @PostMapping
-    public ResponseEntity createReservation(@RequestBody ReservationRequest reservationRequest) {
-        Long id = reservationService.create(reservationRequest);
+    public ResponseEntity createReservation(@RequestBody Long scheduleId, @AuthenticationPrincipal LoginMember loginMember) {
+        Long id = reservationService.create(scheduleId, loginMember);
         return ResponseEntity.created(URI.create("/reservations/" + id)).build();
     }
 
@@ -29,9 +31,8 @@ public class ReservationController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity deleteReservation(@PathVariable Long id) {
-        reservationService.deleteById(id);
-
+    public ResponseEntity deleteReservation(@PathVariable Long id, @AuthenticationPrincipal LoginMember loginMember) {
+        reservationService.deleteById(id, loginMember);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/nextstep/reservation/ReservationService.java
+++ b/src/main/java/nextstep/reservation/ReservationService.java
@@ -1,5 +1,6 @@
 package nextstep.reservation;
 
+import nextstep.member.LoginMember;
 import nextstep.schedule.Schedule;
 import nextstep.schedule.ScheduleDao;
 import nextstep.support.DuplicateEntityException;
@@ -21,12 +22,8 @@ public class ReservationService {
         this.scheduleDao = scheduleDao;
     }
 
-    public Long create(ReservationRequest reservationRequest) {
-        Schedule schedule = scheduleDao.findById(reservationRequest.getScheduleId());
-        if (schedule == null) {
-            throw new NullPointerException();
-        }
-
+    public Long create(Long scheduleId, LoginMember loginMember) {
+        Schedule schedule = scheduleDao.findById(scheduleId).orElseThrow(NullPointerException::new);
         List<Reservation> reservation = reservationDao.findByScheduleId(schedule.getId());
         if (!reservation.isEmpty()) {
             throw new DuplicateEntityException();
@@ -34,7 +31,7 @@ public class ReservationService {
 
         Reservation newReservation = new Reservation(
                 schedule,
-                reservationRequest.getName()
+                loginMember.getUsername()
         );
 
         return reservationDao.save(newReservation);
@@ -49,12 +46,14 @@ public class ReservationService {
         return reservationDao.findAllByThemeIdAndDate(themeId, date);
     }
 
-    public void deleteById(Long id) {
+    public void deleteById(Long id, LoginMember loginMember) {
         Reservation reservation = reservationDao.findById(id);
         if (reservation == null) {
             throw new NullPointerException();
         }
-
+        if (!reservation.getName().equals(loginMember.getUsername())) {
+            throw new IllegalArgumentException();
+        }
         reservationDao.deleteById(id);
     }
 }

--- a/src/main/java/nextstep/schedule/ScheduleDao.java
+++ b/src/main/java/nextstep/schedule/ScheduleDao.java
@@ -12,6 +12,7 @@ import java.sql.PreparedStatement;
 import java.sql.Time;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 public class ScheduleDao {
@@ -21,7 +22,8 @@ public class ScheduleDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    private final RowMapper<Schedule> rowMapper = (resultSet, rowNum) -> new Schedule(
+    private final RowMapper<Schedule> rowMapper = (resultSet, rowNum) -> new
+            Schedule(
             resultSet.getLong("schedule.id"),
             new Theme(
                     resultSet.getLong("theme.id"),
@@ -49,13 +51,13 @@ public class ScheduleDao {
         return keyHolder.getKey().longValue();
     }
 
-    public Schedule findById(Long id) {
+    public Optional<Schedule> findById(Long id) {
         String sql = "SELECT schedule.id, schedule.theme_id, schedule.date, schedule.time, theme.id, theme.name, theme.desc, theme.price " +
                 "from schedule " +
                 "inner join theme on schedule.theme_id = theme.id " +
                 "where schedule.id = ?;";
 
-        return jdbcTemplate.queryForObject(sql, rowMapper, id);
+        return jdbcTemplate.query(sql, rowMapper, id).stream().findFirst();
     }
 
     public List<Schedule> findByThemeIdAndDate(Long themeId, String date) {

--- a/src/test/java/nextstep/member/MemberE2ETest.java
+++ b/src/test/java/nextstep/member/MemberE2ETest.java
@@ -47,7 +47,6 @@ public class MemberE2ETest {
                 .statusCode(HttpStatus.OK.value())
                 .extract();
         assertThat((String) response.path("username")).isEqualTo("username");
-        assertThat((String) response.path("password")).isEqualTo("password");
         assertThat((String) response.path("name")).isEqualTo("name");
         assertThat((String) response.path("phone")).isEqualTo("010-1234-5678");
     }


### PR DESCRIPTION
이번 미션은 제공해준 스켈레톤 코드에 요구하는 기능을 추가하는 방식으로 진행했습니다~

# 기능 요구 사항
- 토큰 발급하는 API
  - username, password 정보를 받고 accessToken(jwt)을 생성해 발급
- 내 정보 조회 API
  - token을 확인하여 유저의 id, username, name, phone 정보를 전달
  - password 정보는 보안을 위해 제외
  - ArgumentResolver를 활용
- 예약 생성 API
  - 예약 생성 시 유저의 id를 함께 저장
- 예약 삭제 API
  - 토큰 확인을 통해 본인의 예약만 삭제

# 어려웠던 점
- 하나씩 구현해가던 기존 미션과는 달리 스켈레톤 코드를 사용하다보니 기존 코드를 파악하는데 오래걸림.
- argumentResolver를 사용하는 과정에서 config파일을 만들지 않아 발생한 에러를 고치기 위해 많이 헤맸음.

# 고민인 점
- 스켈레톤 코드에서는 기능별로 패키지를 만들고 그 하위에 controller, service, dao 등을 모두 한 곳에 넣어서 관리하는데,  지난 미션때는 controller끼리, dao끼리, service끼리 모아 묶어 관리했어서 어떻게 관리하는 것이 더 좋은지 고민입니다~
