### PR TITLE
[winnie.ka] 방탈출 인증 관리 3단계

### DIFF
--- a/src/main/java/nextstep/auth/AdminAuthInterceptor.java
+++ b/src/main/java/nextstep/auth/AdminAuthInterceptor.java
@@ -1,0 +1,33 @@
+package nextstep.auth;
+
+import lombok.RequiredArgsConstructor;
+import nextstep.support.AuthorizationException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+@Component
+public class AdminAuthInterceptor implements HandlerInterceptor {
+    private static final String AUTHORIZATION = "Authorization";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String authHeader = request.getHeader(AUTHORIZATION);
+        String token = jwtTokenProvider.parseTokenFromHeader(authHeader);
+        if (!jwtTokenProvider.validateToken(token)) {
+            throw new AuthorizationException();
+        }
+
+        UserPrincipal principal = jwtTokenProvider.getPrincipal(token);
+        if (!principal.getRole().equals("admin")) {
+            throw new AuthorizationException();
+        }
+
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+}

--- a/src/main/java/nextstep/auth/AuthController.java
+++ b/src/main/java/nextstep/auth/AuthController.java
@@ -14,7 +14,7 @@ public class AuthController {
     }
 
     @PostMapping("/login/token")
-    public ResponseEntity tokenLogin(@RequestBody TokenRequest tokenRequest) {
+    public ResponseEntity<TokenResponse> tokenLogin(@RequestBody TokenRequest tokenRequest) {
         TokenResponse tokenResponse = authService.createToken(tokenRequest);
         return ResponseEntity.ok().body(tokenResponse);
     }

--- a/src/main/java/nextstep/auth/AuthInterceptor.java
+++ b/src/main/java/nextstep/auth/AuthInterceptor.java
@@ -2,13 +2,13 @@ package nextstep.auth;
 
 import nextstep.support.AuthorizationException;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Component
-public class AuthInterceptor extends HandlerInterceptorAdapter {
+public class AuthInterceptor implements HandlerInterceptor {
     private static final String AUTHORIZATION = "Authorization";
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -24,6 +24,6 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
         if (!jwtTokenProvider.validateToken(token)) {
             throw new AuthorizationException();
         }
-        return super.preHandle(request, response, handler);
+        return HandlerInterceptor.super.preHandle(request, response, handler);
     }
 }

--- a/src/main/java/nextstep/auth/AuthPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/auth/AuthPrincipalArgumentResolver.java
@@ -31,7 +31,7 @@ public class AuthPrincipalArgumentResolver implements HandlerMethodArgumentResol
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         String authHeader = webRequest.getHeader(AUTHORIZATION);
         String token = jwtTokenProvider.parseTokenFromHeader(authHeader);
-        String principal = jwtTokenProvider.getPrincipal(token);
-        return memberService.findByUserName(principal);
+        UserPrincipal principal = jwtTokenProvider.getPrincipal(token);
+        return memberService.findByUserName(principal.getUsername());
     }
 }

--- a/src/main/java/nextstep/auth/UserPrincipal.java
+++ b/src/main/java/nextstep/auth/UserPrincipal.java
@@ -1,0 +1,11 @@
+package nextstep.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserPrincipal {
+    private String username;
+    private String role;
+}

--- a/src/main/java/nextstep/config/WebMvcConfiguration.java
+++ b/src/main/java/nextstep/config/WebMvcConfiguration.java
@@ -1,5 +1,7 @@
 package nextstep.config;
 
+import lombok.RequiredArgsConstructor;
+import nextstep.auth.AdminAuthInterceptor;
 import nextstep.auth.AuthInterceptor;
 import nextstep.auth.AuthPrincipalArgumentResolver;
 import org.springframework.context.annotation.Configuration;
@@ -9,22 +11,22 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @Configuration
 public class WebMvcConfiguration implements WebMvcConfigurer {
     private static final String[] REQUIRES_AUTHENTICATION_PATHS = {"/reservations/**"};
 
     private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
     private final AuthInterceptor authInterceptor;
-
-    public WebMvcConfiguration(AuthPrincipalArgumentResolver authPrincipalArgumentResolver, AuthInterceptor authInterceptor) {
-        this.authPrincipalArgumentResolver = authPrincipalArgumentResolver;
-        this.authInterceptor = authInterceptor;
-    }
+    private final AdminAuthInterceptor adminAuthInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns(REQUIRES_AUTHENTICATION_PATHS);
+
+        registry.addInterceptor(adminAuthInterceptor)
+                .addPathPatterns("/admin/**");
     }
 
     @Override

--- a/src/main/java/nextstep/member/Member.java
+++ b/src/main/java/nextstep/member/Member.java
@@ -1,48 +1,25 @@
 package nextstep.member;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Member {
     private Long id;
     private String username;
     private String password;
     private String name;
     private String phone;
-
-    public Member(Long id, String username, String password, String name, String phone) {
-        this.id = id;
-        this.username = username;
-        this.password = password;
-        this.name = name;
-        this.phone = phone;
-    }
+    private String role;
 
     public Member(String username, String password, String name, String phone) {
         this.username = username;
         this.password = password;
         this.name = name;
         this.phone = phone;
-    }
-
-    public Member() {
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getPhone() {
-        return phone;
     }
 
     public boolean checkWrongPassword(String password) {

--- a/src/main/java/nextstep/member/MemberController.java
+++ b/src/main/java/nextstep/member/MemberController.java
@@ -16,13 +16,13 @@ public class MemberController {
     }
 
     @PostMapping
-    public ResponseEntity createMember(@RequestBody MemberRequest memberRequest) {
+    public ResponseEntity<Void> createMember(@RequestBody MemberRequest memberRequest) {
         Long id = memberService.create(memberRequest);
         return ResponseEntity.created(URI.create("/members/" + id)).build();
     }
 
     @GetMapping("/me")
-    public ResponseEntity me(@AuthPrincipal Member member) {
+    public ResponseEntity<Member> me(@AuthPrincipal Member member) {
         return ResponseEntity.ok(member);
     }
 }

--- a/src/main/java/nextstep/member/MemberController.java
+++ b/src/main/java/nextstep/member/MemberController.java
@@ -2,10 +2,7 @@ package nextstep.member;
 
 import nextstep.auth.AuthPrincipal;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -31,6 +28,12 @@ public class MemberController {
     @PostMapping("/admin/members/admin")
     public ResponseEntity<Void> makeUserToAdmin(@RequestBody MemberRequest usernameRequest) {
         memberService.updateUserToAdmin(usernameRequest.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/admin/members/admin")
+    public ResponseEntity<Void> makeAdminToUser(@RequestBody MemberRequest usernameRequest) {
+        memberService.updateAdminToUser(usernameRequest.getUsername());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/member/MemberController.java
+++ b/src/main/java/nextstep/member/MemberController.java
@@ -2,12 +2,14 @@ package nextstep.member;
 
 import nextstep.auth.AuthPrincipal;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
 @RestController
-@RequestMapping("/members")
 public class MemberController {
     private MemberService memberService;
 
@@ -15,14 +17,20 @@ public class MemberController {
         this.memberService = memberService;
     }
 
-    @PostMapping
+    @PostMapping("/members")
     public ResponseEntity<Void> createMember(@RequestBody MemberRequest memberRequest) {
         Long id = memberService.create(memberRequest);
         return ResponseEntity.created(URI.create("/members/" + id)).build();
     }
 
-    @GetMapping("/me")
+    @GetMapping("/members/me")
     public ResponseEntity<Member> me(@AuthPrincipal Member member) {
         return ResponseEntity.ok(member);
+    }
+
+    @PostMapping("/admin/members/admin")
+    public ResponseEntity<Void> makeUserToAdmin(@RequestBody MemberRequest usernameRequest) {
+        memberService.updateUserToAdmin(usernameRequest.getUsername());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/member/MemberDao.java
+++ b/src/main/java/nextstep/member/MemberDao.java
@@ -51,4 +51,9 @@ public class MemberDao {
         String sql = "SELECT id, username, password, name, phone, role from member where username = ?;";
         return jdbcTemplate.queryForObject(sql, rowMapper, username);
     }
+
+    public void updateRoleByUsername(String username, String role) {
+        String sql = "UPDATE member SET role = ? WHERE username = ?;";
+        jdbcTemplate.update(sql, role, username);
+    }
 }

--- a/src/main/java/nextstep/member/MemberDao.java
+++ b/src/main/java/nextstep/member/MemberDao.java
@@ -21,11 +21,12 @@ public class MemberDao {
             resultSet.getString("username"),
             resultSet.getString("password"),
             resultSet.getString("name"),
-            resultSet.getString("phone")
+            resultSet.getString("phone"),
+            resultSet.getString("role")
     );
 
     public Long save(Member member) {
-        String sql = "INSERT INTO member (username, password, name, phone) VALUES (?, ?, ?, ?);";
+        String sql = "INSERT INTO member (username, password, name, phone, role) VALUES (?, ?, ?, ?, 'user');";
         KeyHolder keyHolder = new GeneratedKeyHolder();
 
         jdbcTemplate.update(connection -> {
@@ -42,12 +43,12 @@ public class MemberDao {
     }
 
     public Member findById(Long id) {
-        String sql = "SELECT id, username, password, name, phone from member where id = ?;";
+        String sql = "SELECT id, username, password, name, phone, role from member where id = ?;";
         return jdbcTemplate.queryForObject(sql, rowMapper, id);
     }
 
     public Member findByUsername(String username) {
-        String sql = "SELECT id, username, password, name, phone from member where username = ?;";
+        String sql = "SELECT id, username, password, name, phone, role from member where username = ?;";
         return jdbcTemplate.queryForObject(sql, rowMapper, username);
     }
 }

--- a/src/main/java/nextstep/member/MemberService.java
+++ b/src/main/java/nextstep/member/MemberService.java
@@ -21,4 +21,8 @@ public class MemberService {
     public Member findByUserName(String username) {
         return memberDao.findByUsername(username);
     }
+
+    public void updateUserToAdmin(String username) {
+        memberDao.updateRoleByUsername(username, "admin");
+    }
 }

--- a/src/main/java/nextstep/member/MemberService.java
+++ b/src/main/java/nextstep/member/MemberService.java
@@ -25,4 +25,8 @@ public class MemberService {
     public void updateUserToAdmin(String username) {
         memberDao.updateRoleByUsername(username, "admin");
     }
+
+    public void updateAdminToUser(String username) {
+        memberDao.updateRoleByUsername(username, "user");
+    }
 }

--- a/src/main/java/nextstep/reservation/ReservationController.java
+++ b/src/main/java/nextstep/reservation/ReservationController.java
@@ -20,20 +20,20 @@ public class ReservationController {
     }
 
     @PostMapping
-    public ResponseEntity createReservation(@AuthPrincipal Member member, @RequestBody ReservationRequest reservationRequest) {
+    public ResponseEntity<Void> createReservation(@AuthPrincipal Member member, @RequestBody ReservationRequest reservationRequest) {
         reservationRequest.setUsername(member.getUsername());
         Long id = reservationService.create(reservationRequest);
         return ResponseEntity.created(URI.create("/reservations/" + id)).build();
     }
 
     @GetMapping
-    public ResponseEntity readReservations(@RequestParam Long themeId, @RequestParam String date) {
+    public ResponseEntity<List<Reservation>> readReservations(@RequestParam Long themeId, @RequestParam String date) {
         List<Reservation> results = reservationService.findAllByThemeIdAndDate(themeId, date);
         return ResponseEntity.ok().body(results);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity deleteReservation(@AuthPrincipal Member member, @PathVariable Long id) {
+    public ResponseEntity<Void> deleteReservation(@AuthPrincipal Member member, @PathVariable Long id) {
         reservationService.deleteById(id, member);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/nextstep/schedule/ScheduleController.java
+++ b/src/main/java/nextstep/schedule/ScheduleController.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.util.List;
 
 @RestController
-@RequestMapping("/schedules")
 public class ScheduleController {
     private ScheduleService scheduleService;
 
@@ -15,19 +14,19 @@ public class ScheduleController {
         this.scheduleService = scheduleService;
     }
 
-    @PostMapping
+    @PostMapping("/admin/schedules")
     public ResponseEntity createSchedule(@RequestBody ScheduleRequest scheduleRequest) {
         Long id = scheduleService.create(scheduleRequest);
         return ResponseEntity.created(URI.create("/schedules/" + id)).build();
     }
 
-    @GetMapping
-    public ResponseEntity<List<Schedule>> showReservations(@RequestParam Long themeId, @RequestParam String date) {
+    @GetMapping("/schedules")
+    public ResponseEntity<List<Schedule>> showSchedules(@RequestParam Long themeId, @RequestParam String date) {
         return ResponseEntity.ok().body(scheduleService.findByThemeIdAndDate(themeId, date));
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity deleteReservation(@PathVariable Long id) {
+    @DeleteMapping("/admin/schedules/{id}")
+    public ResponseEntity deleteSchedule(@PathVariable Long id) {
         scheduleService.deleteById(id);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/nextstep/theme/ThemeController.java
+++ b/src/main/java/nextstep/theme/ThemeController.java
@@ -1,19 +1,12 @@
 package nextstep.theme;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
 
 @RestController
-@RequestMapping("/themes")
 public class ThemeController {
     private ThemeService themeService;
 
@@ -21,19 +14,19 @@ public class ThemeController {
         this.themeService = themeService;
     }
 
-    @PostMapping
+    @PostMapping("/admin/themes")
     public ResponseEntity<Void> createTheme(@RequestBody ThemeRequest themeRequest) {
         Long id = themeService.create(themeRequest);
         return ResponseEntity.created(URI.create("/themes/" + id)).build();
     }
 
-    @GetMapping
+    @GetMapping("/themes")
     public ResponseEntity<List<Theme>> showThemes() {
         List<Theme> results = themeService.findAll();
         return ResponseEntity.ok().body(results);
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/admin/themes/{id}")
     public ResponseEntity<Void> deleteTheme(@PathVariable Long id) {
         themeService.delete(id);
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -31,6 +31,7 @@ CREATE TABLE member
     password varchar(20) not null,
     name     varchar(20) not null,
     phone    varchar(20) not null,
+    role     varchar(20) not null default 'user',
     primary key (id),
     UNIQUE (username)
 );

--- a/src/test/java/nextstep/auth/AuthE2ETest.java
+++ b/src/test/java/nextstep/auth/AuthE2ETest.java
@@ -13,8 +13,8 @@ public class AuthE2ETest {
     @DisplayName("토큰을 생성한다")
     @Test
     public void create() {
-        TokenResponse tokenResponse = AuthUtil.createTokenForReservationExistUser();
+        String accessToken = AuthUtil.createTokenForReservationExistUser();
 
-        assertThat(tokenResponse).isNotNull();
+        assertThat(accessToken).isNotNull();
     }
 }

--- a/src/test/java/nextstep/auth/AuthUtil.java
+++ b/src/test/java/nextstep/auth/AuthUtil.java
@@ -4,29 +4,35 @@ import io.restassured.RestAssured;
 import org.springframework.http.MediaType;
 
 public class AuthUtil {
-    private static final String RESERVATION_EXIST_USERNAME = "reservation_exist_user";
+    public static final String RESERVATION_EXIST_USERNAME = "reservation_exist_user";
     private static final String RESERVATION_EXIST_PASSWORD = "password";
-    private static final String RESERVATION_NOT_EXIST_USERNAME = "reservation_exist_user";
+
+    public static final String RESERVATION_NOT_EXIST_USERNAME = "reservation_exist_user";
     private static final String RESERVATION_NOT_EXIST_PASSWORD = "password";
 
-    public static final TokenRequest RESERVATION_EXIST_USER_TOKEN_REQUEST = new TokenRequest(RESERVATION_EXIST_USERNAME, RESERVATION_EXIST_PASSWORD);
-    public static final TokenRequest RESERVATION_NOT_EXIST_USER_TOKEN_REQUEST = new TokenRequest(RESERVATION_NOT_EXIST_USERNAME, RESERVATION_NOT_EXIST_PASSWORD);
+    public static final String ADMIN_USERNAME = "admin";
+    private static final String ADMIN_PASSWORD = "password";
 
-    public static TokenResponse createTokenForReservationExistUser() {
-        return createToken(RESERVATION_EXIST_USER_TOKEN_REQUEST);
+    public static String createTokenForReservationExistUser() {
+        return createToken(new TokenRequest(RESERVATION_EXIST_USERNAME, RESERVATION_EXIST_PASSWORD));
     }
 
-    public static TokenResponse createTokenForReservationNotExistUser() {
-        return createToken(RESERVATION_NOT_EXIST_USER_TOKEN_REQUEST);
+    public static String createTokenForReservationNotExistUser() {
+        return createToken(new TokenRequest(RESERVATION_NOT_EXIST_USERNAME, RESERVATION_NOT_EXIST_PASSWORD));
     }
 
-    public static TokenResponse createToken(TokenRequest tokenRequest) {
+    public static String createTokenForAdminUser() {
+        return createToken(new TokenRequest(ADMIN_USERNAME, ADMIN_PASSWORD));
+    }
+
+    public static String createToken(TokenRequest tokenRequest) {
         return RestAssured
                 .given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(tokenRequest)
                 .when().post("/login/token")
                 .then().log().all()
-                .extract().as(TokenResponse.class);
+                .extract().as(TokenResponse.class)
+                .getAccessToken();
     }
 }

--- a/src/test/java/nextstep/auth/JwtTokenProviderTest.java
+++ b/src/test/java/nextstep/auth/JwtTokenProviderTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,15 +16,15 @@ class JwtTokenProviderTest {
 
     @Test
     void createToken() {
-        String token = jwtTokenProvider.createToken("1");
+        String token = jwtTokenProvider.createToken(new UserPrincipal("1", "user"));
 
         assertThat(jwtTokenProvider.validateToken(token)).isTrue();
     }
 
     @Test
     void getPrincipal() {
-        String token = jwtTokenProvider.createToken("1");
+        String token = jwtTokenProvider.createToken(new UserPrincipal("1", "user"));
 
-        assertThat(jwtTokenProvider.getPrincipal(token)).isEqualTo("1");
+        assertThat(jwtTokenProvider.getPrincipal(token).getUsername()).isEqualTo("1");
     }
 }

--- a/src/test/java/nextstep/member/MemberE2ETest.java
+++ b/src/test/java/nextstep/member/MemberE2ETest.java
@@ -2,8 +2,6 @@ package nextstep.member;
 
 import io.restassured.RestAssured;
 import nextstep.auth.AuthUtil;
-import nextstep.auth.TokenRequest;
-import nextstep.auth.TokenResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,12 +24,10 @@ public class MemberE2ETest {
     @DisplayName("내 정보를 조회한다")
     @Test
     void me() {
-        TokenRequest tokenRequest = AuthUtil.RESERVATION_EXIST_USER_TOKEN_REQUEST;
-        final TokenResponse tokenResponse = AuthUtil.createToken(tokenRequest);
-        final String accessToken = tokenResponse.getAccessToken();
+        String accessToken = AuthUtil.createTokenForReservationExistUser();
 
         Member member = getMemberSelfInfo(accessToken);
-        assertThat(member.getUsername()).isEqualTo(tokenRequest.getUsername());
+        assertThat(member.getUsername()).isEqualTo(AuthUtil.RESERVATION_EXIST_USERNAME);
     }
 
     private static void createMember(MemberRequest memberRequest) {

--- a/src/test/java/nextstep/member/MemberE2ETest.java
+++ b/src/test/java/nextstep/member/MemberE2ETest.java
@@ -44,6 +44,20 @@ public class MemberE2ETest {
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
+    @DisplayName("멤버를 관리자로 승격한다")
+    @Test
+    void updateAdminRoleToUser() {
+        String accessToken = AuthUtil.createTokenForAdminUser();
+        RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new MemberRequest("admin2", "", "", ""))
+                .when().delete("/admin/members/admin")
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
     private static void createMember(MemberRequest memberRequest) {
         RestAssured
                 .given().log().all()

--- a/src/test/java/nextstep/member/MemberE2ETest.java
+++ b/src/test/java/nextstep/member/MemberE2ETest.java
@@ -30,6 +30,20 @@ public class MemberE2ETest {
         assertThat(member.getUsername()).isEqualTo(AuthUtil.RESERVATION_EXIST_USERNAME);
     }
 
+    @DisplayName("멤버를 관리자로 승격한다")
+    @Test
+    void updateUserRoleToAdmin() {
+        String accessToken = AuthUtil.createTokenForAdminUser();
+        RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new MemberRequest(AuthUtil.RESERVATION_EXIST_USERNAME, "", "", ""))
+                .when().post("/admin/members/admin")
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
     private static void createMember(MemberRequest memberRequest) {
         RestAssured
                 .given().log().all()

--- a/src/test/java/nextstep/reservation/ReservationE2ETest.java
+++ b/src/test/java/nextstep/reservation/ReservationE2ETest.java
@@ -23,7 +23,7 @@ class ReservationE2ETest {
 
     @BeforeEach
     void setUp() {
-        RESERVATION_EXIST_USER_ACCESS_TOKEN = AuthUtil.createTokenForReservationExistUser().getAccessToken();
+        RESERVATION_EXIST_USER_ACCESS_TOKEN = AuthUtil.createTokenForReservationExistUser();
     }
 
     @DisplayName("예약을 생성한다")

--- a/src/test/java/nextstep/schedule/ScheduleE2ETest.java
+++ b/src/test/java/nextstep/schedule/ScheduleE2ETest.java
@@ -1,6 +1,7 @@
 package nextstep.schedule;
 
 import io.restassured.RestAssured;
+import nextstep.auth.AuthUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,16 +14,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class ScheduleE2ETest {
+    private static final String ADMIN_USER_ACCESS_TOKEN = AuthUtil.createTokenForAdminUser();
 
     @DisplayName("스케줄을 생성한다")
     @Test
     public void createSchedule() {
+        System.out.println(ADMIN_USER_ACCESS_TOKEN);
+
         ScheduleRequest body = new ScheduleRequest(1L, "2022-08-11", "13:00");
         RestAssured
                 .given().log().all()
+                .auth().oauth2(ADMIN_USER_ACCESS_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(body)
-                .when().post("/schedules")
+                .when().post("/admin/schedules")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
     }
@@ -47,7 +52,8 @@ public class ScheduleE2ETest {
     void delete() {
         var response = RestAssured
                 .given().log().all()
-                .when().delete("/schedules/2")
+                .auth().oauth2(ADMIN_USER_ACCESS_TOKEN)
+                .when().delete("/admin/schedules/2")
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/nextstep/theme/ThemeE2ETest.java
+++ b/src/test/java/nextstep/theme/ThemeE2ETest.java
@@ -1,6 +1,7 @@
 package nextstep.theme;
 
 import io.restassured.RestAssured;
+import nextstep.auth.AuthUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,15 +14,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class ThemeE2ETest {
+    private static final String ADMIN_USER_ACCESS_TOKEN = AuthUtil.createTokenForAdminUser();
+
     @DisplayName("테마를 생성한다")
     @Test
     public void create() {
         ThemeRequest body = new ThemeRequest("테마이름", "테마설명", 22000);
         RestAssured
                 .given().log().all()
+                .auth().oauth2(ADMIN_USER_ACCESS_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(body)
-                .when().post("/themes")
+                .when().post("/admin/themes")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
     }
@@ -48,7 +52,8 @@ public class ThemeE2ETest {
 
         var response = RestAssured
                 .given().log().all()
-                .when().delete("/themes/" + id)
+                .auth().oauth2(ADMIN_USER_ACCESS_TOKEN)
+                .when().delete("/admin/themes/" + id)
                 .then().log().all()
                 .extract();
 
@@ -59,9 +64,10 @@ public class ThemeE2ETest {
         ThemeRequest body = new ThemeRequest("테마이름", "테마설명", 22000);
         String location = RestAssured
                 .given().log().all()
+                .auth().oauth2(ADMIN_USER_ACCESS_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(body)
-                .when().post("/themes")
+                .when().post("/admin/themes")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value())
                 .extract().header("Location");

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,6 +1,7 @@
 INSERT INTO member (username, password, name, phone) VALUES ('reservation_exist_user', 'password', 'name', '010-1234-5678');
 INSERT INTO member (username, password, name, phone) VALUES ('no_reservation_exist_user', 'password', 'name', '010-1234-5678');
 INSERT INTO member (username, password, name, phone, role) VALUES ('admin', 'password', 'name', '010-1234-5678', 'admin');
+INSERT INTO member (username, password, name, phone, role) VALUES ('admin2', 'password', 'name', '010-1234-5678', 'admin');
 
 INSERT INTO theme (name, desc, price) VALUES ('theme1', 'theme1', 1000);
 INSERT INTO theme (name, desc, price) VALUES ('theme2', 'theme2', 2000);

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,5 +1,6 @@
 INSERT INTO member (username, password, name, phone) VALUES ('reservation_exist_user', 'password', 'name', '010-1234-5678');
 INSERT INTO member (username, password, name, phone) VALUES ('no_reservation_exist_user', 'password', 'name', '010-1234-5678');
+INSERT INTO member (username, password, name, phone, role) VALUES ('admin', 'password', 'name', '010-1234-5678', 'admin');
 
 INSERT INTO theme (name, desc, price) VALUES ('theme1', 'theme1', 1000);
 INSERT INTO theme (name, desc, price) VALUES ('theme2', 'theme2', 2000);


### PR DESCRIPTION
안녕하세요! 이번에는 저번 미션 코드에 아래와 같은 관리자 기능을 추가하였습니다.

1. 관리자 역할 추가: 멤버 테이블에 role 필드 추가
2. 관리자 기능 보호: 테마나 스케줄을 등록하고 삭제하는 등의 관리자 기능 API는 path가 /admin으로 시작하게 하고, 관리자 권한을 인터셉터로 체크
3. 관리자 API: 관리자는 다른 멤버의 권한을 일반 유저에서 관리자로, 관리자에서 일반 유저로 변경할 수 있음


다음은 미션을 진행하며 고민되었던 부분입니다.
- 아무나 관리자 회원가입 요청을 보낼 수 있도록 열어두는 건 보안상 취약할 것 같아서 다른 관리자를 통해 관리자를 추가하고 삭제하도록 만들었습니다.
- 권한 체크가 자주 필요해서 매번 DB에 접근하지 않도록 JWT 클레임에 role을 저장했습니다. 그런데 바로 위의 이유로 API를 통해 role이 변할 수 있으니 이 정보를 신뢰할 수 없을 것 같은데 토큰에는 불변인 정보만을 담는 게 맞을까요?

리뷰 항상 감사합니다!!